### PR TITLE
Allow null for null types

### DIFF
--- a/null_handlers.go
+++ b/null_handlers.go
@@ -8,8 +8,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-// NullIntHandler is a TypeHandler for null.Int
-func NullIntHandler(input string, value *Value) error {
+func nullIntHandler(input string, value *Value) error {
 	// Cast
 	nullInt := value.Result.(*null.Int)
 
@@ -31,16 +30,14 @@ func NullIntHandler(input string, value *Value) error {
 	return nil
 }
 
-// NullStringHandler is a TypeHandler for null.String
-func NullStringHandler(input string, value *Value) error {
+func nullStringHandler(input string, value *Value) error {
 	nullString := value.Result.(*null.String)
 	(*nullString).String = input
 	(*nullString).Valid = len(input) != 0
 	return nil
 }
 
-// NullFloatHandler is a TypeHandler for null.Float
-func NullFloatHandler(input string, value *Value) error {
+func nullFloatHandler(input string, value *Value) error {
 	// Cast
 	nullFloat := value.Result.(*null.Float)
 
@@ -62,8 +59,7 @@ func NullFloatHandler(input string, value *Value) error {
 	return nil
 }
 
-// NullBoolHandler is a TypeHandler for null.Bool
-func NullBoolHandler(input string, value *Value) error {
+func nullBoolHandler(input string, value *Value) error {
 	// Cast
 	nullBool := value.Result.(*null.Bool)
 
@@ -85,8 +81,7 @@ func NullBoolHandler(input string, value *Value) error {
 	return nil
 }
 
-// NullTimeHandler is a TypeHandler for null.Time
-func NullTimeHandler(input string, value *Value) error {
+func nullTimeHandler(input string, value *Value) error {
 	// Cast
 	nullTime := value.Result.(*null.Time)
 

--- a/null_handlers.go
+++ b/null_handlers.go
@@ -2,13 +2,23 @@ package validator
 
 import (
 	"errors"
-	"gopkg.in/guregu/null.v3"
 	"strconv"
 	"time"
+
+	"gopkg.in/guregu/null.v3"
 )
 
 // NullIntHandler is a TypeHandler for null.Int
 func NullIntHandler(input string, value *Value) error {
+	// Cast
+	nullInt := value.Result.(*null.Int)
+
+	// Check for empty
+	if len(input) == 0 {
+		(*nullInt).Valid = false
+		return nil
+	}
+
 	// Get int64
 	res, err := strconv.ParseInt(input, 10, 64)
 	if err != nil {
@@ -16,7 +26,6 @@ func NullIntHandler(input string, value *Value) error {
 	}
 
 	// Update null.Int
-	nullInt := value.Result.(*null.Int)
 	(*nullInt).Int64 = int64(res)
 	(*nullInt).Valid = true
 	return nil
@@ -26,12 +35,21 @@ func NullIntHandler(input string, value *Value) error {
 func NullStringHandler(input string, value *Value) error {
 	nullString := value.Result.(*null.String)
 	(*nullString).String = input
-	(*nullString).Valid = true
+	(*nullString).Valid = len(input) != 0
 	return nil
 }
 
 // NullFloatHandler is a TypeHandler for null.Float
 func NullFloatHandler(input string, value *Value) error {
+	// Cast
+	nullFloat := value.Result.(*null.Float)
+
+	// Check for empty
+	if len(input) == 0 {
+		(*nullFloat).Valid = false
+		return nil
+	}
+
 	// Get float64
 	res, err := strconv.ParseFloat(input, 64)
 	if err != nil {
@@ -39,7 +57,6 @@ func NullFloatHandler(input string, value *Value) error {
 	}
 
 	// Update null.Float
-	nullFloat := value.Result.(*null.Float)
 	(*nullFloat).Float64 = res
 	(*nullFloat).Valid = true
 	return nil
@@ -47,6 +64,15 @@ func NullFloatHandler(input string, value *Value) error {
 
 // NullBoolHandler is a TypeHandler for null.Bool
 func NullBoolHandler(input string, value *Value) error {
+	// Cast
+	nullBool := value.Result.(*null.Bool)
+
+	// Check for empty
+	if len(input) == 0 {
+		(*nullBool).Valid = false
+		return nil
+	}
+
 	// Get bool
 	res, err := strconv.ParseBool(input)
 	if err != nil {
@@ -54,7 +80,6 @@ func NullBoolHandler(input string, value *Value) error {
 	}
 
 	// Update null.Bool
-	nullBool := value.Result.(*null.Bool)
 	(*nullBool).Bool = res
 	(*nullBool).Valid = true
 	return nil
@@ -62,6 +87,15 @@ func NullBoolHandler(input string, value *Value) error {
 
 // NullTimeHandler is a TypeHandler for null.Time
 func NullTimeHandler(input string, value *Value) error {
+	// Cast
+	nullTime := value.Result.(*null.Time)
+
+	// Check for empty
+	if len(input) == 0 {
+		(*nullTime).Valid = false
+		return nil
+	}
+
 	// Get time.Time
 	res, err := time.Parse(time.RFC3339, input)
 	if err != nil {
@@ -69,7 +103,6 @@ func NullTimeHandler(input string, value *Value) error {
 	}
 
 	// Update null.Time
-	nullTime := value.Result.(*null.Time)
 	(*nullTime).Time = res
 	(*nullTime).Valid = true
 	return nil

--- a/null_handlers_test.go
+++ b/null_handlers_test.go
@@ -1,11 +1,12 @@
 package validator_test
 
 import (
+	"testing"
+	"time"
+
 	v "github.com/go-carrot/validator"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
-	"testing"
-	"time"
 )
 
 // TestNullInt tests handling of a null.Int as the result
@@ -93,7 +94,7 @@ func TestNullTime(t *testing.T) {
 	assert.Equal(t, successTime.Time.Day(), 1)
 
 	// Test failure case
-	var errorTime time.Time
+	var errorTime null.Time
 	err = v.Validate([]*v.Value{
 		{Result: &errorTime, Name: "time", Input: "abcd", TypeHandler: v.NullTimeHandler},
 	})

--- a/null_handlers_test.go
+++ b/null_handlers_test.go
@@ -20,6 +20,13 @@ func TestNullInt(t *testing.T) {
 	assert.Equal(t, int64(12), id.Int64)
 	assert.True(t, id.Valid)
 
+	// Test null case
+	var nullId null.Int
+	err = v.Validate([]*v.Value{
+		{Result: &nullId, Name: "id", Input: "", TypeHandler: v.NullIntHandler},
+	})
+	assert.False(t, nullId.Valid)
+
 	// Test failure case
 	var failureId null.Int
 	err = v.Validate([]*v.Value{
@@ -39,6 +46,13 @@ func TestNullString(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "hello", slug.String)
 	assert.True(t, slug.Valid)
+
+	// Test null case
+	var nullSlug null.String
+	err = v.Validate([]*v.Value{
+		{Result: &nullSlug, Name: "slug", Input: "", TypeHandler: v.NullStringHandler},
+	})
+	assert.False(t, nullSlug.Valid)
 }
 
 // TestNullFloat tests handling of a null.Float as the result
@@ -51,6 +65,13 @@ func TestNullFloat(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, float64(12.8), id.Float64)
 	assert.True(t, id.Valid)
+
+	// Test null case
+	var nullId null.Float
+	err = v.Validate([]*v.Value{
+		{Result: &nullId, Name: "id", Input: "", TypeHandler: v.NullFloatHandler},
+	})
+	assert.False(t, nullId.Valid)
 
 	// Test failure case
 	var failureId null.Float
@@ -72,6 +93,13 @@ func TestNullBool(t *testing.T) {
 	assert.True(t, someBool.Bool)
 	assert.True(t, someBool.Valid)
 
+	// Test null case
+	var nullBool null.Bool
+	err = v.Validate([]*v.Value{
+		{Result: &nullBool, Name: "some_bool", Input: "", TypeHandler: v.NullBoolHandler},
+	})
+	assert.False(t, nullBool.Valid)
+
 	// Test failure case
 	var someOtherBool null.Bool
 	err = v.Validate([]*v.Value{
@@ -92,6 +120,13 @@ func TestNullTime(t *testing.T) {
 	assert.Equal(t, successTime.Time.Year(), 2012)
 	assert.Equal(t, successTime.Time.Month(), time.November)
 	assert.Equal(t, successTime.Time.Day(), 1)
+
+	// Test null case
+	var nullTime null.Time
+	err = v.Validate([]*v.Value{
+		{Result: &nullTime, Name: "time", Input: "", TypeHandler: v.NullTimeHandler},
+	})
+	assert.False(t, nullTime.Valid)
 
 	// Test failure case
 	var errorTime null.Time

--- a/null_handlers_test.go
+++ b/null_handlers_test.go
@@ -14,7 +14,7 @@ func TestNullInt(t *testing.T) {
 	// Test success case
 	var id null.Int
 	err := v.Validate([]*v.Value{
-		{Result: &id, Name: "id", Input: "12", TypeHandler: v.NullIntHandler},
+		{Result: &id, Name: "id", Input: "12"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(12), id.Int64)
@@ -23,14 +23,14 @@ func TestNullInt(t *testing.T) {
 	// Test null case
 	var nullId null.Int
 	err = v.Validate([]*v.Value{
-		{Result: &nullId, Name: "id", Input: "", TypeHandler: v.NullIntHandler},
+		{Result: &nullId, Name: "id", Input: ""},
 	})
 	assert.False(t, nullId.Valid)
 
 	// Test failure case
 	var failureId null.Int
 	err = v.Validate([]*v.Value{
-		{Result: &failureId, Name: "id", Input: "12a", TypeHandler: v.NullIntHandler},
+		{Result: &failureId, Name: "id", Input: "12a"},
 	})
 	assert.NotNil(t, err)
 	assert.False(t, failureId.Valid)
@@ -41,7 +41,7 @@ func TestNullString(t *testing.T) {
 	// Test success case
 	var slug null.String
 	err := v.Validate([]*v.Value{
-		{Result: &slug, Name: "slug", Input: "hello", TypeHandler: v.NullStringHandler},
+		{Result: &slug, Name: "slug", Input: "hello"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, "hello", slug.String)
@@ -50,7 +50,7 @@ func TestNullString(t *testing.T) {
 	// Test null case
 	var nullSlug null.String
 	err = v.Validate([]*v.Value{
-		{Result: &nullSlug, Name: "slug", Input: "", TypeHandler: v.NullStringHandler},
+		{Result: &nullSlug, Name: "slug", Input: ""},
 	})
 	assert.False(t, nullSlug.Valid)
 }
@@ -60,7 +60,7 @@ func TestNullFloat(t *testing.T) {
 	// Test success case
 	var id null.Float
 	err := v.Validate([]*v.Value{
-		{Result: &id, Name: "id", Input: "12.8", TypeHandler: v.NullFloatHandler},
+		{Result: &id, Name: "id", Input: "12.8"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, float64(12.8), id.Float64)
@@ -69,14 +69,14 @@ func TestNullFloat(t *testing.T) {
 	// Test null case
 	var nullId null.Float
 	err = v.Validate([]*v.Value{
-		{Result: &nullId, Name: "id", Input: "", TypeHandler: v.NullFloatHandler},
+		{Result: &nullId, Name: "id", Input: ""},
 	})
 	assert.False(t, nullId.Valid)
 
 	// Test failure case
 	var failureId null.Float
 	err = v.Validate([]*v.Value{
-		{Result: &failureId, Name: "id", Input: "12.8a", TypeHandler: v.NullFloatHandler},
+		{Result: &failureId, Name: "id", Input: "12.8a"},
 	})
 	assert.NotNil(t, err)
 	assert.False(t, failureId.Valid)
@@ -87,7 +87,7 @@ func TestNullBool(t *testing.T) {
 	// Test success case
 	var someBool null.Bool
 	err := v.Validate([]*v.Value{
-		{Result: &someBool, Name: "some_bool", Input: "true", TypeHandler: v.NullBoolHandler},
+		{Result: &someBool, Name: "some_bool", Input: "true"},
 	})
 	assert.Nil(t, err)
 	assert.True(t, someBool.Bool)
@@ -96,14 +96,14 @@ func TestNullBool(t *testing.T) {
 	// Test null case
 	var nullBool null.Bool
 	err = v.Validate([]*v.Value{
-		{Result: &nullBool, Name: "some_bool", Input: "", TypeHandler: v.NullBoolHandler},
+		{Result: &nullBool, Name: "some_bool", Input: ""},
 	})
 	assert.False(t, nullBool.Valid)
 
 	// Test failure case
 	var someOtherBool null.Bool
 	err = v.Validate([]*v.Value{
-		{Result: &someOtherBool, Name: "some_other_bool", Input: "12.8a", TypeHandler: v.NullBoolHandler},
+		{Result: &someOtherBool, Name: "some_other_bool", Input: "12.8a"},
 	})
 	assert.NotNil(t, err)
 	assert.False(t, someOtherBool.Valid)
@@ -114,7 +114,7 @@ func TestNullTime(t *testing.T) {
 	// Test success case
 	var successTime null.Time
 	err := v.Validate([]*v.Value{
-		{Result: &successTime, Name: "time", Input: "2012-11-01T22:08:41+00:00", TypeHandler: v.NullTimeHandler},
+		{Result: &successTime, Name: "time", Input: "2012-11-01T22:08:41+00:00"},
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, successTime.Time.Year(), 2012)
@@ -124,14 +124,14 @@ func TestNullTime(t *testing.T) {
 	// Test null case
 	var nullTime null.Time
 	err = v.Validate([]*v.Value{
-		{Result: &nullTime, Name: "time", Input: "", TypeHandler: v.NullTimeHandler},
+		{Result: &nullTime, Name: "time", Input: ""},
 	})
 	assert.False(t, nullTime.Valid)
 
 	// Test failure case
 	var errorTime null.Time
 	err = v.Validate([]*v.Value{
-		{Result: &errorTime, Name: "time", Input: "abcd", TypeHandler: v.NullTimeHandler},
+		{Result: &errorTime, Name: "time", Input: "abcd"},
 	})
 	assert.NotNil(t, err)
 }

--- a/primitive_handlers_test.go
+++ b/primitive_handlers_test.go
@@ -1,10 +1,11 @@
 package validator_test
 
 import (
-	v "github.com/go-carrot/validator"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	v "github.com/go-carrot/validator"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestString tests handling of a string as the result
@@ -57,8 +58,7 @@ func TestFloat32(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, float32(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId float32
@@ -100,8 +100,7 @@ func TestFloat64(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, float64(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId float64
@@ -135,8 +134,7 @@ func TestBool(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyBool, Name: "bool", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, false, emptyBool)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetBool bool
@@ -144,7 +142,6 @@ func TestBool(t *testing.T) {
 		{Result: &emptyIsSetBool, Name: "bool", Input: "", Rules: []v.Rule{IsSet}},
 	})
 	assert.NotNil(t, err)
-	assert.Equal(t, false, emptyIsSetBool)
 
 	// Test failure case
 	var failureBool bool
@@ -170,8 +167,7 @@ func TestInt(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId int
@@ -213,8 +209,7 @@ func TestInt8(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int8(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId int8
@@ -256,8 +251,7 @@ func TestInt16(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int16(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId int16
@@ -299,8 +293,7 @@ func TestInt32(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int32(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId int32
@@ -366,8 +359,7 @@ func TestInt64(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int64(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId int64
@@ -409,8 +401,7 @@ func TestUint(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, uint(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId uint
@@ -452,8 +443,7 @@ func TestUint8(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, uint8(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId uint8
@@ -495,8 +485,7 @@ func TestUint16(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, uint16(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId uint16
@@ -538,8 +527,7 @@ func TestUint32(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, uint32(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId uint32
@@ -581,8 +569,7 @@ func TestUint64(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, uint64(0), emptyId)
+	assert.NotNil(t, err)
 
 	// Test empty case with IsSet rule
 	var emptyIsSetId uint64
@@ -626,8 +613,7 @@ func TestTime(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyTime, Name: "time", Input: ""},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, emptyTime.Year(), 1)
+	assert.NotNil(t, err)
 
 	// Test empty with isSet rule
 	err = v.Validate([]*v.Value{

--- a/validator.go
+++ b/validator.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+
+	"gopkg.in/guregu/null.v3"
 )
 
 // Value is the definition of a parameter that you would like to perform validation against.
@@ -45,7 +47,7 @@ func Validate(values []*Value) error {
 			}
 		}
 
-		// Set primitive type handlers
+		// Set primitive + null type handlers
 		if value.TypeHandler == nil {
 			err := applyTypeHandler(value)
 			if err != nil {
@@ -96,6 +98,16 @@ func applyTypeHandler(value *Value) error {
 		value.TypeHandler = uint64Handler
 	case *time.Time:
 		value.TypeHandler = timeHandler
+	case *null.Int:
+		value.TypeHandler = nullIntHandler
+	case *null.String:
+		value.TypeHandler = nullStringHandler
+	case *null.Float:
+		value.TypeHandler = nullFloatHandler
+	case *null.Bool:
+		value.TypeHandler = nullBoolHandler
+	case *null.Time:
+		value.TypeHandler = nullTimeHandler
 	}
 	return nil
 }

--- a/validator.go
+++ b/validator.go
@@ -54,11 +54,9 @@ func Validate(values []*Value) error {
 		}
 
 		// Validate against type
-		if resolvedInput != "" {
-			err := value.TypeHandler(resolvedInput, value)
-			if err != nil {
-				return err
-			}
+		err := value.TypeHandler(resolvedInput, value)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/validator_test.go
+++ b/validator_test.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	v "github.com/go-carrot/validator"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	v "github.com/go-carrot/validator"
+	"github.com/stretchr/testify/assert"
 )
 
 // IsSet is a rule that makes sure the value passed in isn't an empty string
@@ -81,9 +82,7 @@ func TestCustomTypeHandler(t *testing.T) {
 	err = v.Validate([]*v.Value{
 		{Result: &emptyId, Name: "id", Input: "", TypeHandler: nullInt64TypeHandler},
 	})
-	assert.Nil(t, err)
-	assert.Equal(t, int64(0), emptyId.Int64)
-	assert.Equal(t, false, emptyId.Valid)
+	assert.NotNil(t, err)
 
 	// Test error case
 	var errorId sql.NullInt64


### PR DESCRIPTION
## Details

Now with the introduction of easy https://github.com/guregu/null support into this project, I've found the need to want to set a value null.

In the context of a API, I want to be able to send an empty parameter to denote a null value.

This will now yield an error (where it didn't prior to this PR):

```go
var name string
err := Validate([]*Value{
    {Result: &name, Name: "name", Input: ""},
})
// err != nil
```

If you intend to allow nullable values in a validation, you will now have to use the respective null.* value.

```go
var name null.String
err := Validate([]*Value{
    {Result: &name, Name: "name", Input: ""},
})
// err == nil
```

## TODO

- [x] Update README
- [x] Bump Major version
  - Breaking change, due to how empty strings are to be handled for non-null types
- [x] Bring coverage back to 100%
- [x] Remove `IsSet` from [go-carrot/rules](https://github.com/go-carrot/rules).  That is now deprecated due to the fact that a non-null type must be set by default.